### PR TITLE
스냅(중앙, 오브젝트간) 기능 추가

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -3,15 +3,18 @@
  * [Bug] Scaled objects sometimes can not be aligned by edges
  *
  */
-function initAligningGuidelines(canvas) {
+function initAligningGuidelines(canvas, status) {
 
   var ctx = canvas.getSelectionContext(),
-      aligningLineOffset = 5,
-      aligningLineMargin = 4,
-      aligningLineWidth = 1,
-      aligningLineColor = 'rgb(0,255,0)',
-      viewportTransform,
-      zoom = 1;
+    aligningLineOffset = 1,
+    aligningLineMargin = 4,
+    aligningLineWidth = 2,
+    aligningLineColor = 'rgb(254,146,0)',
+    viewportTransform,
+    zoom = 1,
+    verticalLines = [],
+    horizontalLines = [],
+    centerLines = [];
 
   function drawVerticalLine(coords) {
     drawLine(
@@ -29,13 +32,25 @@ function initAligningGuidelines(canvas) {
       coords.y + 0.5);
   }
 
-  function drawLine(x1, y1, x2, y2) {
+  function drawCenterLine(coords) {
+    drawLine(coords.x1,coords.y1,coords.x2,coords.y2,true)
+  }
+
+
+  function drawLine(x1, y1, x2, y2, center=false) {
+    var v = canvas.viewportTransform;
     ctx.save();
+    ctx.transform(v[0], v[1], v[2], v[3], v[4], v[5]);
     ctx.lineWidth = aligningLineWidth;
     ctx.strokeStyle = aligningLineColor;
     ctx.beginPath();
-    ctx.moveTo(((x1+viewportTransform[4])*zoom), ((y1+viewportTransform[5])*zoom));
-    ctx.lineTo(((x2+viewportTransform[4])*zoom), ((y2+viewportTransform[5])*zoom));
+    if (!center) {
+      ctx.setLineDash([5,10])
+    }
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    // ctx.moveTo(((x1+viewportTransform[4])*zoom), ((y1+viewportTransform[5])*zoom));
+    // ctx.lineTo(((x2+viewportTransform[4])*zoom), ((y2+viewportTransform[5])*zoom));
     ctx.stroke();
     ctx.restore();
   }
@@ -51,28 +66,19 @@ function initAligningGuidelines(canvas) {
     return false;
   }
 
-  var verticalLines = [],
-      horizontalLines = [];
-
-  canvas.on('mouse:down', function () {
-    viewportTransform = canvas.viewportTransform;
-    zoom = canvas.getZoom();
-  });
-
-  canvas.on('object:moving', function(e) {
-
+  const sanp = function(e) {
     var activeObject = e.target,
-        canvasObjects = canvas.getObjects(),
-        activeObjectCenter = activeObject.getCenterPoint(),
-        activeObjectLeft = activeObjectCenter.x,
-        activeObjectTop = activeObjectCenter.y,
-        activeObjectBoundingRect = activeObject.getBoundingRect(),
-        activeObjectHeight = activeObjectBoundingRect.height / viewportTransform[3],
-        activeObjectWidth = activeObjectBoundingRect.width / viewportTransform[0],
-        horizontalInTheRange = false,
-        verticalInTheRange = false,
-        transform = canvas._currentTransform;
-
+      canvasObjects = canvas.getObjects(),
+      activeObjectCenter = activeObject.getCenterPoint(),
+      activeObjectLeft = activeObjectCenter.x,
+      activeObjectTop = activeObjectCenter.y,
+      activeObjectBoundingRect = activeObject.getBoundingRect(),
+      activeObjectHeight = activeObjectBoundingRect.height / viewportTransform[3],
+      activeObjectWidth = activeObjectBoundingRect.width / viewportTransform[0],
+      horizontalInTheRange = false,
+      verticalInTheRange = false,
+      centerInTheRange = false,
+      transform = canvas._currentTransform;
     if (!transform) return;
 
     // It should be trivial to DRY this up by encapsulating (repeating) creation of x1, x2, y1, and y2 into functions,
@@ -80,132 +86,246 @@ function initAligningGuidelines(canvas) {
 
     for (var i = canvasObjects.length; i--; ) {
 
-      if (canvasObjects[i] === activeObject) continue;
-
       var objectCenter = canvasObjects[i].getCenterPoint(),
-          objectLeft = objectCenter.x,
-          objectTop = objectCenter.y,
-          objectBoundingRect = canvasObjects[i].getBoundingRect(),
-          objectHeight = objectBoundingRect.height / viewportTransform[3],
-          objectWidth = objectBoundingRect.width / viewportTransform[0];
+        objectLeft = objectCenter.x,
+        objectTop = objectCenter.y,
+        objectBoundingRect = canvasObjects[i].getBoundingRect(),
+        objectHeight = objectBoundingRect.height / viewportTransform[3],
+        objectWidth = objectBoundingRect.width / viewportTransform[0];
 
-      // snap by the horizontal center line
-      if (isInRange(objectLeft, activeObjectLeft)) {
-        verticalInTheRange = true;
-        verticalLines.push({
-          x: objectLeft,
-          y1: (objectTop < activeObjectTop)
-            ? (objectTop - objectHeight / 2 - aligningLineOffset)
-            : (objectTop + objectHeight / 2 + aligningLineOffset),
-          y2: (activeObjectTop > objectTop)
-            ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
-            : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
-        });
-        activeObject.setPositionByOrigin(new fabric.Point(objectLeft, activeObjectTop), 'center', 'center');
+      // 선택된 오브젝트면 아무것도 안하고 패스
+      if (canvasObjects[i] === activeObject) {
+        continue;
       }
 
-      // snap by the left edge
-      if (isInRange(objectLeft - objectWidth / 2, activeObjectLeft - activeObjectWidth / 2)) {
-        verticalInTheRange = true;
-        verticalLines.push({
-          x: objectLeft - objectWidth / 2,
-          y1: (objectTop < activeObjectTop)
-            ? (objectTop - objectHeight / 2 - aligningLineOffset)
-            : (objectTop + objectHeight / 2 + aligningLineOffset),
-          y2: (activeObjectTop > objectTop)
-            ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
-            : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
-        });
-        activeObject.setPositionByOrigin(new fabric.Point(objectLeft - objectWidth / 2 + activeObjectWidth / 2, activeObjectTop), 'center', 'center');
+      // 가이드마스크라면 중앙 라인만 표시
+      else if (canvasObjects[i].resource_type === 'guide_mask') {
+        // horizontal center line
+        if (isInRange(objectLeft, activeObjectLeft)) {
+          centerInTheRange = true;
+          centerLines.push({
+            x1: objectLeft,
+            y1: objectTop - objectHeight / 2 - aligningLineOffset,
+            x2: objectLeft,
+            y2: objectTop + objectHeight / 2 + aligningLineOffset
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(objectLeft, activeObjectTop), 'center', 'center');
+        }
+        // vertical center line
+        if (isInRange(objectTop, activeObjectTop)) {
+          centerInTheRange = true;
+          centerLines.push({
+            x1: objectLeft - objectWidth / 2 - aligningLineOffset,
+            y1: objectTop,
+            x2: objectLeft + objectWidth / 2 + aligningLineOffset,
+            y2: objectTop
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop), 'center', 'center');
+        }
       }
 
-      // snap by the right edge
-      if (isInRange(objectLeft + objectWidth / 2, activeObjectLeft + activeObjectWidth / 2)) {
-        verticalInTheRange = true;
-        verticalLines.push({
-          x: objectLeft + objectWidth / 2,
-          y1: (objectTop < activeObjectTop)
-            ? (objectTop - objectHeight / 2 - aligningLineOffset)
-            : (objectTop + objectHeight / 2 + aligningLineOffset),
-          y2: (activeObjectTop > objectTop)
-            ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
-            : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
-        });
-        activeObject.setPositionByOrigin(new fabric.Point(objectLeft + objectWidth / 2 - activeObjectWidth / 2, activeObjectTop), 'center', 'center');
-      }
+      // 그 외 오브젝트면 상하좌우 라인 모두 표시
+      else {
+        // snap by the horizontal center line
+        if (isInRange(objectLeft, activeObjectLeft)) {
+          verticalInTheRange = true;
+          verticalLines.push({
+            x: objectLeft,
+            y1: (objectTop < activeObjectTop)
+              ? (objectTop - objectHeight / 2 - aligningLineOffset)
+              : (objectTop + objectHeight / 2 + aligningLineOffset),
+            y2: (activeObjectTop > objectTop)
+              ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
+              : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(objectLeft, activeObjectTop), 'center', 'center');
+        }
 
-      // snap by the vertical center line
-      if (isInRange(objectTop, activeObjectTop)) {
-        horizontalInTheRange = true;
-        horizontalLines.push({
-          y: objectTop,
-          x1: (objectLeft < activeObjectLeft)
-            ? (objectLeft - objectWidth / 2 - aligningLineOffset)
-            : (objectLeft + objectWidth / 2 + aligningLineOffset),
-          x2: (activeObjectLeft > objectLeft)
-            ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
-            : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
-        });
-        activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop), 'center', 'center');
-      }
+        // snap by the vertical center line
+        if (isInRange(objectTop, activeObjectTop)) {
+          horizontalInTheRange = true;
+          horizontalLines.push({
+            y: objectTop,
+            x1: (objectLeft < activeObjectLeft)
+              ? (objectLeft - objectWidth / 2 - aligningLineOffset)
+              : (objectLeft + objectWidth / 2 + aligningLineOffset),
+            x2: (activeObjectLeft > objectLeft)
+              ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
+              : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop), 'center', 'center');
+        }
 
-      // snap by the top edge
-      if (isInRange(objectTop - objectHeight / 2, activeObjectTop - activeObjectHeight / 2)) {
-        horizontalInTheRange = true;
-        horizontalLines.push({
-          y: objectTop - objectHeight / 2,
-          x1: (objectLeft < activeObjectLeft)
-            ? (objectLeft - objectWidth / 2 - aligningLineOffset)
-            : (objectLeft + objectWidth / 2 + aligningLineOffset),
-          x2: (activeObjectLeft > objectLeft)
-            ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
-            : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
-        });
-        activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop - objectHeight / 2 + activeObjectHeight / 2), 'center', 'center');
-      }
+        // snap by the left edge(왼,왼)
+        if (isInRange(objectLeft - objectWidth / 2, activeObjectLeft - activeObjectWidth / 2)) {
+          verticalInTheRange = true;
+          verticalLines.push({
+            x: objectLeft - objectWidth / 2,
+            y1: (objectTop < activeObjectTop)
+              ? (objectTop - objectHeight / 2 - aligningLineOffset)
+              : (objectTop + objectHeight / 2 + aligningLineOffset),
+            y2: (activeObjectTop > objectTop)
+              ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
+              : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(objectLeft - objectWidth / 2 + activeObjectWidth / 2, activeObjectTop), 'center', 'center');
+        }
 
-      // snap by the bottom edge
-      if (isInRange(objectTop + objectHeight / 2, activeObjectTop + activeObjectHeight / 2)) {
-        horizontalInTheRange = true;
-        horizontalLines.push({
-          y: objectTop + objectHeight / 2,
-          x1: (objectLeft < activeObjectLeft)
-            ? (objectLeft - objectWidth / 2 - aligningLineOffset)
-            : (objectLeft + objectWidth / 2 + aligningLineOffset),
-          x2: (activeObjectLeft > objectLeft)
-            ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
-            : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
-        });
-        activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop + objectHeight / 2 - activeObjectHeight / 2), 'center', 'center');
+        // snap by the left edge(왼,오)
+        if (isInRange(objectLeft - objectWidth / 2, activeObjectLeft + activeObjectWidth / 2)) {
+          verticalInTheRange = true;
+          verticalLines.push({
+            x: objectLeft - objectWidth / 2,
+            y1: (objectTop < activeObjectTop)
+              ? (objectTop - objectHeight / 2 - aligningLineOffset)
+              : (objectTop + objectHeight / 2 + aligningLineOffset),
+            y2: (activeObjectTop > objectTop)
+              ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
+              : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(objectLeft - objectWidth / 2 - activeObjectWidth / 2, activeObjectTop), 'center', 'center');
+        }
+
+        // snap by the right edge(오,오)
+        if (isInRange(objectLeft + objectWidth / 2, activeObjectLeft + activeObjectWidth / 2)) {
+          verticalInTheRange = true;
+          verticalLines.push({
+            x: objectLeft + objectWidth / 2,
+            y1: (objectTop < activeObjectTop)
+              ? (objectTop - objectHeight / 2 - aligningLineOffset)
+              : (objectTop + objectHeight / 2 + aligningLineOffset),
+            y2: (activeObjectTop > objectTop)
+              ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
+              : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(objectLeft + objectWidth / 2 - activeObjectWidth / 2, activeObjectTop), 'center', 'center');
+        }
+
+        // object right + activeobject left(오,왼)
+        if (isInRange(objectLeft + objectWidth / 2, activeObjectLeft - activeObjectWidth / 2)) {
+          verticalInTheRange = true;
+          verticalLines.push({
+            x: objectLeft + objectWidth / 2,
+            y1: (objectTop < activeObjectTop)
+              ? (objectTop - objectHeight / 2 - aligningLineOffset)
+              : (objectTop + objectHeight / 2 + aligningLineOffset),
+            y2: (activeObjectTop > objectTop)
+              ? (activeObjectTop + activeObjectHeight / 2 + aligningLineOffset)
+              : (activeObjectTop - activeObjectHeight / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(objectLeft + objectWidth / 2 + activeObjectWidth / 2, activeObjectTop), 'center', 'center');
+        }
+
+        // snap by the top edge(위,위)
+        if (isInRange(objectTop - objectHeight / 2, activeObjectTop - activeObjectHeight / 2)) {
+          horizontalInTheRange = true;
+          horizontalLines.push({
+            y: objectTop - objectHeight / 2,
+            x1: (objectLeft < activeObjectLeft)
+              ? (objectLeft - objectWidth / 2 - aligningLineOffset)
+              : (objectLeft + objectWidth / 2 + aligningLineOffset),
+            x2: (activeObjectLeft > objectLeft)
+              ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
+              : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop - objectHeight / 2 + activeObjectHeight / 2), 'center', 'center');
+        }
+
+        // snap by the top edge(위,아래)
+        if (isInRange(objectTop - objectHeight / 2, activeObjectTop + activeObjectHeight / 2)) {
+          horizontalInTheRange = true;
+          horizontalLines.push({
+            y: objectTop - objectHeight / 2,
+            x1: (objectLeft < activeObjectLeft)
+              ? (objectLeft - objectWidth / 2 - aligningLineOffset)
+              : (objectLeft + objectWidth / 2 + aligningLineOffset),
+            x2: (activeObjectLeft > objectLeft)
+              ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
+              : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop - objectHeight / 2 - activeObjectHeight / 2), 'center', 'center');
+        }
+
+        // snap by the bottom edge(아래,아래)
+        if (isInRange(objectTop + objectHeight / 2, activeObjectTop + activeObjectHeight / 2)) {
+          horizontalInTheRange = true;
+          horizontalLines.push({
+            y: objectTop + objectHeight / 2,
+            x1: (objectLeft < activeObjectLeft)
+              ? (objectLeft - objectWidth / 2 - aligningLineOffset)
+              : (objectLeft + objectWidth / 2 + aligningLineOffset),
+            x2: (activeObjectLeft > objectLeft)
+              ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
+              : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop + objectHeight / 2 - activeObjectHeight / 2), 'center', 'center');
+        }
+
+        // snap by the bottom edge(아래,위)
+        if (isInRange(objectTop + objectHeight / 2, activeObjectTop - activeObjectHeight / 2)) {
+          horizontalInTheRange = true;
+          horizontalLines.push({
+            y: objectTop + objectHeight / 2,
+            x1: (objectLeft < activeObjectLeft)
+              ? (objectLeft - objectWidth / 2 - aligningLineOffset)
+              : (objectLeft + objectWidth / 2 + aligningLineOffset),
+            x2: (activeObjectLeft > objectLeft)
+              ? (activeObjectLeft + activeObjectWidth / 2 + aligningLineOffset)
+              : (activeObjectLeft - activeObjectWidth / 2 - aligningLineOffset)
+          });
+          activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop + objectHeight / 2 + activeObjectHeight / 2), 'center', 'center');
+        }
       }
     }
 
-    if (!horizontalInTheRange) {
-      horizontalLines.length = 0;
-    }
+    // if (!horizontalInTheRange) {
+    //   horizontalLines.length = 0;
+    // }
+    //
+    // if (!verticalInTheRange) {
+    //   verticalLines.length = 0;
+    // }
+    //
+    //   if (!centerInTheRange) {
+    //     centerLines.length = 0;
+    // }
 
-    if (!verticalInTheRange) {
-      verticalLines.length = 0;
-    }
-  });
+  }
 
-  canvas.on('before:render', function() {
-    canvas.clearContext(canvas.contextTop);
-  });
+  const beforeSnap = function() {
+    viewportTransform = canvas.viewportTransform;
+  }
 
-  canvas.on('after:render', function() {
-    for (var i = verticalLines.length; i--; ) {
+  const clear = function() {
+    canvas.clearContext(ctx);
+  }
+
+  const draw = function() {
+    for (var i=verticalLines.length; i--; ) {
       drawVerticalLine(verticalLines[i]);
     }
-    for (var i = horizontalLines.length; i--; ) {
+    for (var i=horizontalLines.length; i--; ) {
       drawHorizontalLine(horizontalLines[i]);
     }
+    for (var i=centerLines.length; i--; ) {
+      drawCenterLine(centerLines[i])
+    }
+    verticalLines.length = horizontalLines.length = centerLines.length = 0;
+  }
 
-    verticalLines.length = horizontalLines.length = 0;
-  });
-
-  canvas.on('mouse:up', function() {
-    verticalLines.length = horizontalLines.length = 0;
+  const afterSnap = function() {
+    verticalLines.length = horizontalLines.length = centerLines.length =  0;
     canvas.renderAll();
-  });
+  }
+
+  if (status) {
+    canvas.on('mouse:down', beforeSnap);
+    canvas.on('before:render', clear);
+    canvas.on('object:moving', sanp);
+    canvas.on('after:render', draw);
+    canvas.on('mouse:up', afterSnap);
+  } else {
+    canvas.off('before:render');
+    canvas.off('after:render');
+  }
 }

--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -11,7 +11,6 @@ function initAligningGuidelines(canvas, status) {
     aligningLineWidth = 2,
     aligningLineColor = 'rgb(254,146,0)',
     viewportTransform,
-    zoom = 1,
     verticalLines = [],
     horizontalLines = [],
     centerLines = [];
@@ -31,11 +30,6 @@ function initAligningGuidelines(canvas, status) {
       coords.x2 > coords.x1 ? coords.x2 : coords.x1,
       coords.y + 0.5);
   }
-
-  function drawCenterLine(coords) {
-    drawLine(coords.x1,coords.y1,coords.x2,coords.y2,true)
-  }
-
 
   function drawLine(x1, y1, x2, y2, center=false) {
     var v = canvas.viewportTransform;
@@ -156,7 +150,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop), 'center', 'center');
         }
 
-        // snap by the left edge(왼,왼)
+        // object left + activeobject left(왼,왼)
         if (isInRange(objectLeft - objectWidth / 2, activeObjectLeft - activeObjectWidth / 2)) {
           verticalInTheRange = true;
           verticalLines.push({
@@ -171,7 +165,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(objectLeft - objectWidth / 2 + activeObjectWidth / 2, activeObjectTop), 'center', 'center');
         }
 
-        // snap by the left edge(왼,오)
+        // object left + activeobject right(왼,오)
         if (isInRange(objectLeft - objectWidth / 2, activeObjectLeft + activeObjectWidth / 2)) {
           verticalInTheRange = true;
           verticalLines.push({
@@ -186,7 +180,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(objectLeft - objectWidth / 2 - activeObjectWidth / 2, activeObjectTop), 'center', 'center');
         }
 
-        // snap by the right edge(오,오)
+        // object right + activeobject right(오,오)
         if (isInRange(objectLeft + objectWidth / 2, activeObjectLeft + activeObjectWidth / 2)) {
           verticalInTheRange = true;
           verticalLines.push({
@@ -216,7 +210,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(objectLeft + objectWidth / 2 + activeObjectWidth / 2, activeObjectTop), 'center', 'center');
         }
 
-        // snap by the top edge(위,위)
+        // object top + activeobject top(위,위)
         if (isInRange(objectTop - objectHeight / 2, activeObjectTop - activeObjectHeight / 2)) {
           horizontalInTheRange = true;
           horizontalLines.push({
@@ -231,7 +225,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop - objectHeight / 2 + activeObjectHeight / 2), 'center', 'center');
         }
 
-        // snap by the top edge(위,아래)
+        // object top + activeobject bottom(위,아래)
         if (isInRange(objectTop - objectHeight / 2, activeObjectTop + activeObjectHeight / 2)) {
           horizontalInTheRange = true;
           horizontalLines.push({
@@ -246,7 +240,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop - objectHeight / 2 - activeObjectHeight / 2), 'center', 'center');
         }
 
-        // snap by the bottom edge(아래,아래)
+        // object bottom + activeobject bottom(아래,아래)
         if (isInRange(objectTop + objectHeight / 2, activeObjectTop + activeObjectHeight / 2)) {
           horizontalInTheRange = true;
           horizontalLines.push({
@@ -261,7 +255,7 @@ function initAligningGuidelines(canvas, status) {
           activeObject.setPositionByOrigin(new fabric.Point(activeObjectLeft, objectTop + objectHeight / 2 - activeObjectHeight / 2), 'center', 'center');
         }
 
-        // snap by the bottom edge(아래,위)
+        // object bottom + activeobject top(아래,위)
         if (isInRange(objectTop + objectHeight / 2, activeObjectTop - activeObjectHeight / 2)) {
           horizontalInTheRange = true;
           horizontalLines.push({
@@ -308,7 +302,7 @@ function initAligningGuidelines(canvas, status) {
       drawHorizontalLine(horizontalLines[i]);
     }
     for (var i=centerLines.length; i--; ) {
-      drawCenterLine(centerLines[i])
+      drawLine(centerLines[i].x1,centerLines[i].y1,centerLines[i].x2,centerLines[i].y2,true)
     }
     verticalLines.length = horizontalLines.length = centerLines.length = 0;
   }


### PR DESCRIPTION
### 해결하려는 문제
- 캔버스 내 오브젝트 간 스냅 및 가이드 라인 추가
- 캔버스 내 하얀 부분(guidemask)을 기준으로 가로/세로 중앙 스냅 및 가이드 라인 추가

### 해결 방법
- 기존 fabricjs에 존재하는 aligning_guidelines.js 파일을 수정
- 처음 에디터에 들어올 경우, 스냅 기능 활성화된 상태 -> 더보기란에서 기능 끌수 있도록 토글 추가
- stroke 색상을 주황색으로 변경
- 일부 변경해줘야하는 변수 수정(기존 fabric에서 canvas.contextTop을 ctx로) : 해주지 않으면 before:render관련 이벤트 핸들에서 에러 발생함

1. 오브젝트 간 스냅
- 기존에는 각 오브젝트의 상하좌우가 각각 상은 상끼리, 좌는 좌끼리 등 같은 방향인 경우에만 스냅 기능이 활성화되었으나, 각 오브젝트의 상하좌우가 반대여도 활성화되도록 코드 추가
- 오브젝트 간의 경우, 점선으로 선이 표시되도록 함

2. 중앙 스냅
- tooning의 특징(canvas가 아닌 guidemask를 기준으로)에 맞춰 코드 수정
- guidemask는 하나의 오브젝트이므로 fabricjs에 기 존재하던 centering_guidelines.js를 이용할 필요없음
- 중앙 스냅의 경우 실선으로 선이 표시되도록 함

### 첨부
- 동작 화면
![스냅완성](https://user-images.githubusercontent.com/96458726/178220527-8b4187bc-6f49-446c-b50e-214ad2200230.gif)

- pr 머지되면 tooning repo에서 수정한 코드도 pr 올릴 예정(함수, 토글 추가 등 수정사항 존재)