### PR TITLE
스냅 이벤트 off관리를 위해서 코드 수정

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -1,13 +1,12 @@
 /**
  * Should objects be aligned by a bounding box?
  * [Bug] Scaled objects sometimes can not be aligned by edges
- *
  */
-function initAligningGuidelines(canvas, status) {
+function initAligningGuidelines(canvas, status, handler) {
 
   var ctx = canvas.getSelectionContext(),
     aligningLineOffset = 1,
-    aligningLineMargin = 4,
+    aligningLineMargin = 5,
     aligningLineWidth = 1,
     aligningLineColor = 'rgb(254,146,0)',
     viewportTransform,
@@ -43,8 +42,6 @@ function initAligningGuidelines(canvas, status) {
     }
     ctx.moveTo(x1, y1);
     ctx.lineTo(x2, y2);
-    // ctx.moveTo(((x1+viewportTransform[4])*zoom), ((y1+viewportTransform[5])*zoom));
-    // ctx.lineTo(((x2+viewportTransform[4])*zoom), ((y2+viewportTransform[5])*zoom));
     ctx.stroke();
     ctx.restore();
   }
@@ -60,8 +57,8 @@ function initAligningGuidelines(canvas, status) {
     return false;
   }
 
-  const sanp = function(e) {
-    var activeObject = e.target,
+  handler.objectSanp = (event) => {
+    var activeObject = event.target,
       canvasObjects = canvas.getObjects(),
       activeObjectCenter = activeObject.getCenterPoint(),
       activeObjectLeft = activeObjectCenter.x,
@@ -271,30 +268,17 @@ function initAligningGuidelines(canvas, status) {
         }
       }
     }
-
-    // if (!horizontalInTheRange) {
-    //   horizontalLines.length = 0;
-    // }
-    //
-    // if (!verticalInTheRange) {
-    //   verticalLines.length = 0;
-    // }
-    //
-    //   if (!centerInTheRange) {
-    //     centerLines.length = 0;
-    // }
-
   }
 
-  const beforeSnap = function() {
+  handler.beforeSnap = (event) => {
     viewportTransform = canvas.viewportTransform;
   }
 
-  const clear = function() {
+  handler.clearSnap = (event) => {
     canvas.clearContext(ctx);
   }
 
-  const draw = function() {
+  handler.drawSnap = (event) => {
     for (var i=verticalLines.length; i--; ) {
       drawVerticalLine(verticalLines[i]);
     }
@@ -307,19 +291,14 @@ function initAligningGuidelines(canvas, status) {
     verticalLines.length = horizontalLines.length = centerLines.length = 0;
   }
 
-  const afterSnap = function() {
+  handler.afterSnap = (event) => {
     verticalLines.length = horizontalLines.length = centerLines.length =  0;
     canvas.renderAll();
   }
 
-  if (status) {
-    canvas.on('mouse:down', beforeSnap);
-    canvas.on('before:render', clear);
-    canvas.on('object:moving', sanp);
-    canvas.on('after:render', draw);
-    canvas.on('mouse:up', afterSnap);
-  } else {
-    canvas.off('before:render');
-    canvas.off('after:render');
-  }
+  canvas.on('mouse:down', handler.beforeSnap);
+  canvas.on('before:render', handler.clearSnap);
+  canvas.on('object:moving', handler.objectSanp);
+  canvas.on('after:render', handler.drawSnap);
+  canvas.on('mouse:up', handler.afterSnap);
 }


### PR DESCRIPTION
[관련 이슈]
https://github.com/toonsquare/tooning-repo/issues/3810

[문제]
- 스냅기능을 off 했음에도 불구하고 선만 보이지 않을뿐 기능이 유지

[기존]
- 스냅 관련 기능 자체를 전부 끄는 것이 아닌, 스냅선만 보이지 않도록 처리됨
- 함수 내에서 snap기능을 off할수가 없음(기존 코드 상으로는 토글을 통해 특정이벤트를 켜고 끄는게 아니라 켤때는 특정한 것을 키고, 끌때는 해당 이벤트에 걸린 모든 핸들러를 꺼버림)

[변경]
- 핸들러를 추가해서 외부에서 특정기능만 off할 수 있도록 수정